### PR TITLE
Use snapshot version of trellis-db

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
 
     <trellis.version>0.9.0-SNAPSHOT</trellis.version>
-    <trellisdb.version>0.2.3</trellisdb.version>
+    <trellisdb.version>0.3.0-SNAPSHOT</trellisdb.version>
     <javaee.version>8.0</javaee.version>
     <junit.version>5.4.2</junit.version>
 


### PR DESCRIPTION
Use the snapshot version of trellis-db so that the API dependencies are lined up properly.